### PR TITLE
Draggable objects and decos

### DIFF
--- a/src/levelEditor/LevelInspector.jsx
+++ b/src/levelEditor/LevelInspector.jsx
@@ -336,25 +336,6 @@ export default function LevelInspector({
 		});
 	}, []);
 
-	const onEntityTransformUpdate = useCallback(
-		(
-			index: number,
-			type: GameEntityType,
-			properties: {
-				[key: string]: string | number | null,
-			}
-		) => {
-			dispatch({
-				type: 'editEntityPropertiesOnLevel',
-				coordinates: currentCoordinates,
-				index,
-				properties,
-				entityType: type,
-			});
-		},
-		[currentCoordinates, dispatch]
-	);
-
 	return (
 		// eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
 		<div
@@ -376,7 +357,7 @@ export default function LevelInspector({
 						objectIndexHover={objectIndexHover}
 						onDecoHover={setDecoIndexHover}
 						onEntityClick={onEntityClick}
-						onEntityTransformUpdate={onEntityTransformUpdate}
+						onEntityTransformUpdate={onEntityEditProperties}
 						onMapMouseClick={onMapMouseClick}
 						onMapMouseLeave={onMapMouseLeave}
 						onMapMouseMove={onMapMouseMove}

--- a/src/levelEditor/LevelInspector.jsx
+++ b/src/levelEditor/LevelInspector.jsx
@@ -336,6 +336,25 @@ export default function LevelInspector({
 		});
 	}, []);
 
+	const onEntityTransformUpdate = useCallback(
+		(
+			index: number,
+			type: GameEntityType,
+			properties: {
+				[key: string]: string | number | null,
+			}
+		) => {
+			dispatch({
+				type: 'editEntityPropertiesOnLevel',
+				coordinates: currentCoordinates,
+				index,
+				properties,
+				entityType: type,
+			});
+		},
+		[currentCoordinates, dispatch]
+	);
+
 	return (
 		// eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
 		<div
@@ -357,6 +376,7 @@ export default function LevelInspector({
 						objectIndexHover={objectIndexHover}
 						onDecoHover={setDecoIndexHover}
 						onEntityClick={onEntityClick}
+						onEntityTransformUpdate={onEntityTransformUpdate}
 						onMapMouseClick={onMapMouseClick}
 						onMapMouseLeave={onMapMouseLeave}
 						onMapMouseMove={onMapMouseMove}

--- a/src/levelEditor/preview/LevelPreview.jsx
+++ b/src/levelEditor/preview/LevelPreview.jsx
@@ -33,6 +33,13 @@ type Props = $ReadOnly<{
 	onMapMouseMove: (ev: SyntheticMouseEvent<HTMLDivElement>) => mixed,
 	onEntityClick: (entityIndex: number, entityType: GameEntityType) => mixed,
 	onObjectHover: (objectIndex: ?number) => mixed,
+	onEntityTransformUpdate: (
+		index: number,
+		type: GameEntityType,
+		properties: {
+			[key: string]: string | number | null,
+		}
+	) => mixed,
 	decoIndexHover: ?number,
 	onDecoHover: (decoIndex: ?number) => mixed,
 }>;
@@ -108,8 +115,10 @@ export default function LevelPreview(props: Props): React$Node {
 					editorToolType={props.editorToolType}
 					entityIndexHover={props.objectIndexHover}
 					level={props.level}
+					mapMouseMoveCoordinates={mapMouseMoveCoordinates}
 					onEntityClick={props.onEntityClick}
 					onEntityHover={props.onObjectHover}
+					onEntityTransformUpdate={props.onEntityTransformUpdate}
 				/>
 			) : null}
 
@@ -138,8 +147,10 @@ export default function LevelPreview(props: Props): React$Node {
 					editorToolType={props.editorToolType}
 					entityIndexHover={props.decoIndexHover}
 					level={props.level}
+					mapMouseMoveCoordinates={mapMouseMoveCoordinates}
 					onEntityClick={props.onEntityClick}
 					onEntityHover={props.onDecoHover}
+					onEntityTransformUpdate={props.onEntityTransformUpdate}
 				/>
 			) : null}
 

--- a/src/levelEditor/preview/LevelPreview.jsx
+++ b/src/levelEditor/preview/LevelPreview.jsx
@@ -35,10 +35,10 @@ type Props = $ReadOnly<{
 	onObjectHover: (objectIndex: ?number) => mixed,
 	onEntityTransformUpdate: (
 		index: number,
-		type: GameEntityType,
 		properties: {
 			[key: string]: string | number | null,
-		}
+		},
+		type: GameEntityType
 	) => mixed,
 	decoIndexHover: ?number,
 	onDecoHover: (decoIndex: ?number) => mixed,

--- a/src/levelEditor/preview/LevelPreviewDecos.jsx
+++ b/src/levelEditor/preview/LevelPreviewDecos.jsx
@@ -21,10 +21,10 @@ type Props = $ReadOnly<{
 	onEntityHover: (entityIndex: ?number) => mixed,
 	onEntityTransformUpdate: (
 		index: number,
-		type: GameEntityType,
 		properties: {
 			[key: string]: string | number | null,
-		}
+		},
+		type: GameEntityType
 	) => mixed,
 }>;
 
@@ -83,10 +83,14 @@ function LevelPreviewDecos(props: Props): React$Node {
 				onMouseEnter={() => props.onEntityHover(index)}
 				onMouseLeave={() => props.onEntityHover(null)}
 				onTransformUpdate={(t: TransformType) =>
-					props.onEntityTransformUpdate(index, 'DECO', {
-						x: t.x,
-						y: t.y,
-					})
+					props.onEntityTransformUpdate(
+						index,
+						{
+							x: t.x,
+							y: t.y,
+						},
+						'DECO'
+					)
 				}
 				origin={transformOrigin}
 				renderOffset={renderOffset}

--- a/src/levelEditor/preview/LevelPreviewObjects.jsx
+++ b/src/levelEditor/preview/LevelPreviewObjects.jsx
@@ -26,10 +26,10 @@ type Props = $ReadOnly<{
 	onEntityHover: (entityIndex: ?number) => mixed,
 	onEntityTransformUpdate: (
 		index: number,
-		type: GameEntityType,
 		properties: {
 			[key: string]: string | number | null,
-		}
+		},
+		type: GameEntityType
 	) => mixed,
 }>;
 
@@ -68,7 +68,7 @@ function LevelPreviewObjects(props: Props): React$Node {
 				onMouseEnter={() => props.onEntityHover(index)}
 				onMouseLeave={() => props.onEntityHover(null)}
 				onTransformUpdate={(t: TransformType) =>
-					props.onEntityTransformUpdate(index, 'OBJECT', {x: t.x, y: t.y})
+					props.onEntityTransformUpdate(index, {x: t.x, y: t.y}, 'OBJECT')
 				}
 				origin={transformOrigin}
 				renderOffset={isCustomDog ? [0, -110 / 2] : null}

--- a/src/levelEditor/preview/LevelPreviewObjects.jsx
+++ b/src/levelEditor/preview/LevelPreviewObjects.jsx
@@ -10,17 +10,27 @@ import {
 import type {EditorToolType} from '../types/EditorToolType';
 import type {GameEntityType} from '../types/GameEntityType';
 import type {LevelType} from '../types/LevelType';
+import type {TransformType} from '../types/TransformType';
 import getGameObjectSimpleName from '../util/getGameObjectSimpleName';
 
 import LevelPreviewCustomDog from './LevelPreviewCustomDog';
 import styles from './LevelPreviewObjects.module.css';
+import TransformDiv from './TransformDiv';
 
 type Props = $ReadOnly<{
 	level: LevelType,
 	editorToolType: EditorToolType,
 	entityIndexHover: ?number,
+	mapMouseMoveCoordinates: ?[number, number],
 	onEntityClick: (entityIndex: number, entityType: GameEntityType) => mixed,
 	onEntityHover: (entityIndex: ?number) => mixed,
+	onEntityTransformUpdate: (
+		index: number,
+		type: GameEntityType,
+		properties: {
+			[key: string]: string | number | null,
+		}
+	) => mixed,
 }>;
 
 function LevelPreviewObjects(props: Props): React$Node {
@@ -32,29 +42,19 @@ function LevelPreviewObjects(props: Props): React$Node {
 	return levelObjects.map((obj, index) => {
 		const isCustomDog = obj.obj === 'objCustomDog';
 
-		const transforms = [];
-		let transformOrigin = '';
+		let transformOrigin = null;
+
 		if (isCustomDog) {
-			transformOrigin = `${IDLE_ORIGIN_X / DOG_RES_SCALE}px ${
-				IDLE_ORIGIN_Y / DOG_RES_SCALE
-			}px`;
-
-			if (typeof obj.angle === 'number' && obj.angle !== 0) {
-				transforms.push(`rotate(${-obj.angle}deg)`);
-			}
-
-			if (typeof obj.xscale === 'number') {
-				transforms.push(`scaleX(${obj.xscale})`);
-			}
-
-			if (typeof obj.yscale === 'number') {
-				transforms.push(`scaleY(${obj.yscale})`);
-			}
+			transformOrigin = [
+				IDLE_ORIGIN_X / DOG_RES_SCALE,
+				IDLE_ORIGIN_Y / DOG_RES_SCALE,
+			];
 		}
 
 		return (
 			// eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
-			<div
+			<TransformDiv
+				baseTransform={{x: obj.x, y: obj.y}}
 				className={
 					styles.item +
 					' ' +
@@ -63,28 +63,22 @@ function LevelPreviewObjects(props: Props): React$Node {
 					(props.editorToolType !== 'Select' ? styles.disabled : '')
 				}
 				key={index}
+				mapMouseMoveCoordinates={props.mapMouseMoveCoordinates}
 				onClick={() => props.onEntityClick(index, 'OBJECT')}
 				onMouseEnter={() => props.onEntityHover(index)}
 				onMouseLeave={() => props.onEntityHover(null)}
-				style={{
-					left: obj.x,
-					top:
-						obj.y +
-						// Need to adjust Y position here so the whole box is moved
-						(isCustomDog ? -110 / 2 : 0),
-					transform:
-						transforms.length !== 0
-							? 'translate(-50%, -50%) ' + transforms.join(' ')
-							: null,
-					transformOrigin,
-				}}
+				onTransformUpdate={(t: TransformType) =>
+					props.onEntityTransformUpdate(index, 'OBJECT', {x: t.x, y: t.y})
+				}
+				origin={transformOrigin}
+				renderOffset={isCustomDog ? [0, -110 / 2] : null}
 			>
 				{isCustomDog ? (
 					<LevelPreviewCustomDog obj={obj} />
 				) : (
 					getGameObjectSimpleName(obj.obj)
 				)}
-			</div>
+			</TransformDiv>
 		);
 	});
 }

--- a/src/levelEditor/preview/TransformDiv.jsx
+++ b/src/levelEditor/preview/TransformDiv.jsx
@@ -1,0 +1,163 @@
+// @flow strict
+
+import {memo, useCallback, useEffect, useReducer, useState} from 'react';
+
+import type {TransformType} from '../types/TransformType';
+
+type TransformAction = 'move';
+
+type Props = $ReadOnly<{
+	baseTransform: TransformType,
+	className: string,
+	renderOffset: ?[number, number],
+	mapMouseMoveCoordinates: ?[number, number],
+	origin: ?[number, number],
+	onTransformUpdate: (transform: TransformType) => mixed,
+	children: React$Node,
+	...
+}>;
+
+type ReducerAction =
+	| {type: 'move', deltaX: number, deltaY: number}
+	| {type: null};
+
+function TransformDiv({
+	baseTransform,
+	renderOffset,
+	mapMouseMoveCoordinates,
+	children,
+	onTransformUpdate,
+	origin,
+	className,
+	...otherProps
+}: Props): React$Node {
+	const [currentTransform, dispatch] = useReducer(
+		transformReducer,
+		baseTransform
+	);
+	const [transformAction, setTransformAction] =
+		useState<?TransformAction>(null);
+	const [prevMousePos, setPrevMousePos] = useState<?[number, number]>(null);
+
+	function onMouseDown(
+		ev: SyntheticMouseEvent<HTMLDivElement>,
+		action: TransformAction
+	) {
+		if (mapMouseMoveCoordinates != null) {
+			ev.preventDefault();
+			setPrevMousePos(mapMouseMoveCoordinates);
+			setTransformAction(action);
+		}
+	}
+
+	const onMouseUp = useCallback(
+		(ev: MouseEvent) => {
+			if (transformAction != null) {
+				setPrevMousePos(null);
+				setTransformAction(null);
+				onTransformUpdate(currentTransform);
+			}
+		},
+		[transformAction, currentTransform, onTransformUpdate]
+	);
+
+	useEffect(() => {
+		document.addEventListener('mouseup', onMouseUp);
+
+		return () => {
+			document.removeEventListener('mouseup', onMouseUp);
+		};
+	}, [onMouseUp]);
+
+	function transformReducer(
+		prevTransform: TransformType,
+		action: ReducerAction
+	) {
+		switch (action.type) {
+			case 'move':
+				return {
+					...prevTransform,
+					x: prevTransform.x + action.deltaX,
+					y: prevTransform.y + action.deltaY,
+				};
+			default:
+				return prevTransform;
+		}
+	}
+
+	useEffect(() => {
+		if (
+			prevMousePos != null &&
+			mapMouseMoveCoordinates != null &&
+			transformAction != null
+		) {
+			setPrevMousePos(mapMouseMoveCoordinates);
+
+			dispatch({
+				type: transformAction,
+				deltaX: mapMouseMoveCoordinates[0] - prevMousePos[0],
+				deltaY: mapMouseMoveCoordinates[1] - prevMousePos[1],
+			});
+		}
+	}, [transformAction, mapMouseMoveCoordinates, prevMousePos]);
+
+	const getTransformStyle = useCallback(() => {
+		const transforms = [];
+		let transformOrigin = '';
+
+		transformOrigin = origin != null ? `${origin[0]}px ${origin[1]}px` : '';
+
+		if (
+			typeof currentTransform.xScale === 'number' &&
+			currentTransform.xScale !== 1
+		) {
+			transforms.push(`scaleX(${currentTransform.xScale})`);
+		}
+
+		if (
+			typeof currentTransform.yScale === 'number' &&
+			currentTransform.yScale !== 1
+		) {
+			transforms.push(`scaleY(${currentTransform.yScale})`);
+		}
+
+		if (
+			typeof currentTransform.angle === 'number' &&
+			currentTransform.angle !== 0
+		) {
+			transforms.push(
+				`rotate(${
+					-1 *
+					Math.sign(
+						currentTransform.xScale != null ? currentTransform.xScale : 1
+					) *
+					(currentTransform.angle != null ? currentTransform.angle : 0)
+				}deg)`
+			);
+		}
+
+		return {
+			left: currentTransform.x + (renderOffset != null ? renderOffset[0] : 0),
+			top: currentTransform.y + (renderOffset != null ? renderOffset[1] : 0),
+			transform: transforms.length !== 0 ? transforms.join(' ') : null,
+			transformOrigin,
+		};
+	}, [currentTransform, renderOffset, origin]);
+
+	return (
+		// eslint-disable-next-line jsx-a11y/no-static-element-interactions
+		<div
+			{...otherProps}
+			className={className}
+			onMouseDown={(ev) => onMouseDown(ev, 'move')}
+			style={getTransformStyle()}
+		>
+			{children}
+		</div>
+	);
+}
+
+export default (memo<Props>(TransformDiv): React$AbstractComponent<
+	Props,
+	mixed
+>);

--- a/src/levelEditor/preview/TransformDiv.jsx
+++ b/src/levelEditor/preview/TransformDiv.jsx
@@ -19,6 +19,7 @@ type Props = $ReadOnly<{
 
 type ReducerAction =
 	| {type: 'move', deltaX: number, deltaY: number}
+	| {type: 'set', transform: TransformType}
 	| {type: null};
 
 function TransformDiv({
@@ -69,6 +70,20 @@ function TransformDiv({
 		};
 	}, [onMouseUp]);
 
+	// Mainly for updating transform when it gets updated by something other than dragging/dropping
+	useEffect(() => {
+		dispatch({
+			type: 'set',
+			transform: baseTransform,
+		});
+	}, [
+		baseTransform.x,
+		baseTransform.y,
+		baseTransform.xScale,
+		baseTransform.yScale,
+		baseTransform.angle,
+	]);
+
 	function transformReducer(
 		prevTransform: TransformType,
 		action: ReducerAction
@@ -80,12 +95,16 @@ function TransformDiv({
 					x: prevTransform.x + action.deltaX,
 					y: prevTransform.y + action.deltaY,
 				};
+			case 'set':
+				return action.transform;
 			default:
 				return prevTransform;
 		}
 	}
 
 	useEffect(() => {
+		// Decided to detect changes to mapMouseMoveCoordinates instead of using mousemove events since
+		// mapMouseMoveCoordinates gets updated by LevelInspector anyways.
 		if (
 			prevMousePos != null &&
 			mapMouseMoveCoordinates != null &&

--- a/src/levelEditor/preview/TransformDiv.jsx
+++ b/src/levelEditor/preview/TransformDiv.jsx
@@ -162,7 +162,7 @@ export default function TransformDiv({
 			top: currentTransform.y + (renderOffset != null ? renderOffset[1] : 0),
 			transform: transforms.length !== 0 ? transforms.join(' ') : null,
 			transformOrigin,
-			cursor: currentTransformAction === 'MOVE' ? 'move' : 'crosshair',
+			cursor: currentTransformAction === 'MOVE' ? 'move' : 'pointer',
 		};
 	}, [currentTransform, renderOffset, origin, currentTransformAction]);
 

--- a/src/levelEditor/types/TransformType.js
+++ b/src/levelEditor/types/TransformType.js
@@ -1,0 +1,9 @@
+// @flow strict
+
+export type TransformType = {
+	x: number,
+	y: number,
+	xScale?: number,
+	yScale?: number,
+	angle?: number,
+};


### PR DESCRIPTION
Working implementation for issue https://github.com/chicory-pizza/chicory-data/issues/37

- How it works:
   - Replace div that wraps around the object/deco with a `TransformDiv`
   - `TransformDiv` updates its own internal position when user drags the div around
   - When user stops dragging, `TransformDiv` emits event of updated position. `LevelInspector` picks up on the change and calls dispatch to update object/deco properties
- Note: Most of the code is designed in mind for supporting more transform operations in the future, such as scaling and rotating. But for now, moving is the only supported operation.